### PR TITLE
Compatibility for docker 1.7 changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vagrant

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/client.go
@@ -376,6 +376,11 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 	for key, val := range streamOptions.headers {
 		req.Header.Set(key, val)
 	}
+
+	q := req.URL.Query()
+	q.Set("stream", "true")
+	req.URL.RawQuery = q.Encode()
+
 	var resp *http.Response
 	protocol := c.endpointURL.Scheme
 	address := c.endpointURL.Path

--- a/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
+++ b/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/container.go
@@ -668,8 +668,9 @@ func (c *Client) Stats(opts StatsOptions) (retErr error) {
 
 	go func() {
 		err := c.stream("GET", fmt.Sprintf("/containers/%s/stats", opts.ID), streamOptions{
-			rawJSONStream: true,
-			stdout:        writeCloser,
+			setRawTerminal: true,
+			rawJSONStream:  true,
+			stdout:         writeCloser,
 		})
 		if err != nil {
 			dockerError, ok := err.(*Error)


### PR DESCRIPTION
Fixes https://github.com/remind101/dockerstats/issues/1

Docker added a "stream" param to the `/containers/(id)/stats` endpoint in 1.7, and defaulted it to false, which breaks backwards compatibility. For now, I'm just changing the vendored docker client to add the param. This works with docker 1.6 and docker 1.7.