### PR TITLE
Drain events

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -10,14 +10,21 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
+var DefaultAdapter Adapter = &nullAdapter{}
+
 // L2MetTemplate is a template for outputing metrics as l2met samples.
-var L2MetTemplate = `sample#{{.Name}}={{.Value}} source={{.Container.Name}}.{{.Hostname}}`
+var L2MetTemplate = `{{.Type}}#{{.Name}}={{.Value}} source={{.Container.Name}}.{{.Hostname}}`
 
 var hostname string
 
 func init() {
 	hostname, _ = os.Hostname()
 }
+
+type nullAdapter struct{}
+
+func (a *nullAdapter) Stats(_ *Stats) error { return nil }
+func (a *nullAdapter) Event(_ *Event) error { return nil }
 
 // LogAdapter is a drain that drains the metrics to stdout in l2met format.
 type LogAdapter struct {
@@ -42,6 +49,8 @@ func NewLogAdapter(tmpl string) (*LogAdapter, error) {
 }
 
 func (a *LogAdapter) Event(event *Event) error {
+	w := &l2metWriter{template: a.Template, container: event.Container}
+	w.incr(fmt.Sprintf("Container.%s", strings.Title(event.Status)))
 	return nil
 }
 
@@ -49,60 +58,60 @@ func (a *LogAdapter) Stats(stats *Stats) error {
 	w := &l2metWriter{template: a.Template, container: stats.Container}
 
 	// Network
-	w.write("Network.RxDropped", stats.Network.RxDropped)
-	w.write("Network.RxBytes", stats.Network.RxBytes)
-	w.write("Network.RxErrors", stats.Network.RxErrors)
-	w.write("Network.TxPackets", stats.Network.TxPackets)
-	w.write("Network.RxPackets", stats.Network.RxPackets)
-	w.write("Network.TxErrors", stats.Network.TxErrors)
-	w.write("Network.TxBytes", stats.Network.TxBytes)
+	w.sample("Network.RxDropped", stats.Network.RxDropped)
+	w.sample("Network.RxBytes", stats.Network.RxBytes)
+	w.sample("Network.RxErrors", stats.Network.RxErrors)
+	w.sample("Network.TxPackets", stats.Network.TxPackets)
+	w.sample("Network.RxPackets", stats.Network.RxPackets)
+	w.sample("Network.TxErrors", stats.Network.TxErrors)
+	w.sample("Network.TxBytes", stats.Network.TxBytes)
 
 	// MemoryStats
-	w.write("MemoryStats.Stats.TotalPgmafault", stats.MemoryStats.Stats.TotalPgmafault)
-	w.write("MemoryStats.Stats.Cache", stats.MemoryStats.Stats.Cache)
-	w.write("MemoryStats.Stats.MappedFile", stats.MemoryStats.Stats.MappedFile)
-	w.write("MemoryStats.Stats.TotalInactiveFile", stats.MemoryStats.Stats.TotalInactiveFile)
-	w.write("MemoryStats.Stats.Pgpgout", stats.MemoryStats.Stats.Pgpgout)
-	w.write("MemoryStats.Stats.Rss", stats.MemoryStats.Stats.Rss)
-	w.write("MemoryStats.Stats.TotalMappedFile", stats.MemoryStats.Stats.TotalMappedFile)
-	w.write("MemoryStats.Stats.Writeback", stats.MemoryStats.Stats.Writeback)
-	w.write("MemoryStats.Stats.Unevictable", stats.MemoryStats.Stats.Unevictable)
-	w.write("MemoryStats.Stats.Pgpgin", stats.MemoryStats.Stats.Pgpgin)
-	w.write("MemoryStats.Stats.TotalUnevictable", stats.MemoryStats.Stats.TotalUnevictable)
-	w.write("MemoryStats.Stats.Pgmajfault", stats.MemoryStats.Stats.Pgmajfault)
-	w.write("MemoryStats.Stats.TotalRss", stats.MemoryStats.Stats.TotalRss)
-	w.write("MemoryStats.Stats.TotalRssHuge", stats.MemoryStats.Stats.TotalRssHuge)
-	w.write("MemoryStats.Stats.TotalWriteback", stats.MemoryStats.Stats.TotalWriteback)
-	w.write("MemoryStats.Stats.TotalInactiveAnon", stats.MemoryStats.Stats.TotalInactiveAnon)
-	w.write("MemoryStats.Stats.RssHuge", stats.MemoryStats.Stats.RssHuge)
-	w.write("MemoryStats.Stats.HierarchicalMemoryLimit", stats.MemoryStats.Stats.HierarchicalMemoryLimit)
-	w.write("MemoryStats.Stats.TotalPgfault", stats.MemoryStats.Stats.TotalPgfault)
-	w.write("MemoryStats.Stats.TotalActiveFile", stats.MemoryStats.Stats.TotalActiveFile)
-	w.write("MemoryStats.Stats.ActiveAnon", stats.MemoryStats.Stats.ActiveAnon)
-	w.write("MemoryStats.Stats.TotalActiveAnon", stats.MemoryStats.Stats.TotalActiveAnon)
-	w.write("MemoryStats.Stats.TotalPgpgout", stats.MemoryStats.Stats.TotalPgpgout)
-	w.write("MemoryStats.Stats.TotalCache", stats.MemoryStats.Stats.TotalCache)
-	w.write("MemoryStats.Stats.InactiveAnon", stats.MemoryStats.Stats.InactiveAnon)
-	w.write("MemoryStats.Stats.ActiveFile", stats.MemoryStats.Stats.ActiveFile)
-	w.write("MemoryStats.Stats.Pgfault", stats.MemoryStats.Stats.Pgfault)
-	w.write("MemoryStats.Stats.InactiveFile", stats.MemoryStats.Stats.InactiveFile)
-	w.write("MemoryStats.Stats.TotalPgpgin", stats.MemoryStats.Stats.TotalPgpgin)
-	w.write("MemoryStats.MaxUsage", stats.MemoryStats.MaxUsage)
-	w.write("MemoryStats.Usage", stats.MemoryStats.Usage)
-	w.write("MemoryStats.Failcnt", stats.MemoryStats.Failcnt)
-	w.write("MemoryStats.Limit", stats.MemoryStats.Limit)
+	w.sample("MemoryStats.Stats.TotalPgmafault", stats.MemoryStats.Stats.TotalPgmafault)
+	w.sample("MemoryStats.Stats.Cache", stats.MemoryStats.Stats.Cache)
+	w.sample("MemoryStats.Stats.MappedFile", stats.MemoryStats.Stats.MappedFile)
+	w.sample("MemoryStats.Stats.TotalInactiveFile", stats.MemoryStats.Stats.TotalInactiveFile)
+	w.sample("MemoryStats.Stats.Pgpgout", stats.MemoryStats.Stats.Pgpgout)
+	w.sample("MemoryStats.Stats.Rss", stats.MemoryStats.Stats.Rss)
+	w.sample("MemoryStats.Stats.TotalMappedFile", stats.MemoryStats.Stats.TotalMappedFile)
+	w.sample("MemoryStats.Stats.Writeback", stats.MemoryStats.Stats.Writeback)
+	w.sample("MemoryStats.Stats.Unevictable", stats.MemoryStats.Stats.Unevictable)
+	w.sample("MemoryStats.Stats.Pgpgin", stats.MemoryStats.Stats.Pgpgin)
+	w.sample("MemoryStats.Stats.TotalUnevictable", stats.MemoryStats.Stats.TotalUnevictable)
+	w.sample("MemoryStats.Stats.Pgmajfault", stats.MemoryStats.Stats.Pgmajfault)
+	w.sample("MemoryStats.Stats.TotalRss", stats.MemoryStats.Stats.TotalRss)
+	w.sample("MemoryStats.Stats.TotalRssHuge", stats.MemoryStats.Stats.TotalRssHuge)
+	w.sample("MemoryStats.Stats.TotalWriteback", stats.MemoryStats.Stats.TotalWriteback)
+	w.sample("MemoryStats.Stats.TotalInactiveAnon", stats.MemoryStats.Stats.TotalInactiveAnon)
+	w.sample("MemoryStats.Stats.RssHuge", stats.MemoryStats.Stats.RssHuge)
+	w.sample("MemoryStats.Stats.HierarchicalMemoryLimit", stats.MemoryStats.Stats.HierarchicalMemoryLimit)
+	w.sample("MemoryStats.Stats.TotalPgfault", stats.MemoryStats.Stats.TotalPgfault)
+	w.sample("MemoryStats.Stats.TotalActiveFile", stats.MemoryStats.Stats.TotalActiveFile)
+	w.sample("MemoryStats.Stats.ActiveAnon", stats.MemoryStats.Stats.ActiveAnon)
+	w.sample("MemoryStats.Stats.TotalActiveAnon", stats.MemoryStats.Stats.TotalActiveAnon)
+	w.sample("MemoryStats.Stats.TotalPgpgout", stats.MemoryStats.Stats.TotalPgpgout)
+	w.sample("MemoryStats.Stats.TotalCache", stats.MemoryStats.Stats.TotalCache)
+	w.sample("MemoryStats.Stats.InactiveAnon", stats.MemoryStats.Stats.InactiveAnon)
+	w.sample("MemoryStats.Stats.ActiveFile", stats.MemoryStats.Stats.ActiveFile)
+	w.sample("MemoryStats.Stats.Pgfault", stats.MemoryStats.Stats.Pgfault)
+	w.sample("MemoryStats.Stats.InactiveFile", stats.MemoryStats.Stats.InactiveFile)
+	w.sample("MemoryStats.Stats.TotalPgpgin", stats.MemoryStats.Stats.TotalPgpgin)
+	w.sample("MemoryStats.MaxUsage", stats.MemoryStats.MaxUsage)
+	w.sample("MemoryStats.Usage", stats.MemoryStats.Usage)
+	w.sample("MemoryStats.Failcnt", stats.MemoryStats.Failcnt)
+	w.sample("MemoryStats.Limit", stats.MemoryStats.Limit)
 
 	// CPUStats
 	for i, v := range stats.CPUStats.CPUUsage.PercpuUsage {
-		w.write(fmt.Sprintf("CPUStats.CPUUsage.PercpuUsage.%d", i), v)
+		w.sample(fmt.Sprintf("CPUStats.CPUUsage.PercpuUsage.%d", i), v)
 	}
-	w.write("CPUStats.CPUUsage.UsageInUsermode", stats.CPUStats.CPUUsage.UsageInUsermode)
-	w.write("CPUStats.CPUUsage.TotalUsage", stats.CPUStats.CPUUsage.TotalUsage)
-	w.write("CPUStats.CPUUsage.UsageInKernelmode", stats.CPUStats.CPUUsage.UsageInKernelmode)
-	w.write("CPUStats.SystemCPUUsage", stats.CPUStats.SystemCPUUsage)
-	w.write("CPUStats.ThrottlingData.Periods", stats.CPUStats.ThrottlingData.Periods)
-	w.write("CPUStats.ThrottlingData.ThrottledPeriods", stats.CPUStats.ThrottlingData.ThrottledPeriods)
-	w.write("CPUStats.ThrottlingData.ThrottledTime", stats.CPUStats.ThrottlingData.ThrottledTime)
+	w.sample("CPUStats.CPUUsage.UsageInUsermode", stats.CPUStats.CPUUsage.UsageInUsermode)
+	w.sample("CPUStats.CPUUsage.TotalUsage", stats.CPUStats.CPUUsage.TotalUsage)
+	w.sample("CPUStats.CPUUsage.UsageInKernelmode", stats.CPUStats.CPUUsage.UsageInKernelmode)
+	w.sample("CPUStats.SystemCPUUsage", stats.CPUStats.SystemCPUUsage)
+	w.sample("CPUStats.ThrottlingData.Periods", stats.CPUStats.ThrottlingData.Periods)
+	w.sample("CPUStats.ThrottlingData.ThrottledPeriods", stats.CPUStats.ThrottlingData.ThrottledPeriods)
+	w.sample("CPUStats.ThrottlingData.ThrottledTime", stats.CPUStats.ThrottlingData.ThrottledTime)
 
 	return nil
 }
@@ -111,6 +120,7 @@ func (a *LogAdapter) Stats(stats *Stats) error {
 // template.
 type stat struct {
 	Container *docker.Container
+	Type      string
 	Name      string
 	Value     interface{}
 }
@@ -138,10 +148,19 @@ type l2metWriter struct {
 	container *docker.Container
 }
 
-func (w *l2metWriter) write(name string, value interface{}) {
+func (w *l2metWriter) sample(name string, value interface{}) {
+	w.write("sample", name, value)
+}
+
+func (w *l2metWriter) incr(name string) {
+	w.write("count", name, 1)
+}
+
+func (w *l2metWriter) write(typ, name string, value interface{}) {
 	b := new(bytes.Buffer)
 	data := stat{
 		Container: w.container,
+		Type:      typ,
 		Name:      name,
 		Value:     value,
 	}

--- a/adapter.go
+++ b/adapter.go
@@ -41,7 +41,11 @@ func NewLogAdapter(tmpl string) (*LogAdapter, error) {
 	}, nil
 }
 
-func (a *LogAdapter) Drain(stats *Stats) error {
+func (a *LogAdapter) Event(event *Event) error {
+	return nil
+}
+
+func (a *LogAdapter) Stats(stats *Stats) error {
 	w := &l2metWriter{template: a.Template, container: stats.Container}
 
 	// Network

--- a/stats.go
+++ b/stats.go
@@ -19,13 +19,6 @@ import (
 // default to 10 seconds.
 var DefaultResolution = 10
 
-// whitelistedEvents not in this list will be ignored.
-var whitelistedEvents = map[string]bool{
-	"start":   true,
-	"restart": true,
-	"die":     true,
-}
-
 // Stats represents a set of stats from a container at a given point in time.
 type Stats struct {
 	*docker.Stats
@@ -99,11 +92,6 @@ func (s *Stat) Run() error {
 	}
 
 	for event := range events {
-		// Ingore events not in the whitelist.
-		if !whitelistedEvents[event.Status] {
-			continue
-		}
-
 		container, err := s.addContainer(event.ID)
 		if err != nil {
 			debug("add container: err: %s", err)


### PR DESCRIPTION
This will output metrics for container start, restart and die events:

```
count#Container.Die=1 source=elated_turing.Erics-MacBook.local
count#Container.Start=1 source=nostalgic_rosalind.Erics-MacBook.local
count#Container.Die=1 source=nostalgic_rosalind.Erics-MacBook.local
count#Container.Start=1 source=loving_mayer.Erics-MacBook.local
count#Container.Die=1 source=loving_mayer.Erics-MacBook.local
```

In our setup, the source will also be broken out by app, so we'll know exactly what apps are in a potential restart loop. Much better than trying to parse the ECS logs and it'll work for our non ECS containers.